### PR TITLE
Fixed the error cannot convert type (Int) to shape while model fitting

### DIFF
--- a/nbeats_tensorflow/model.py
+++ b/nbeats_tensorflow/model.py
@@ -322,7 +322,7 @@ def build_fn(backcast_time_idx,
 
     # Define the model input, the input shape is
     # equal to the length of the lookback period.
-    x = tf.keras.layers.Input(shape=len(backcast_time_idx))
+    x = tf.keras.layers.Input(shape=(len(backcast_time_idx),))
 
     # Loop across the different stacks.
     for s in range(len(stacks)):


### PR DESCRIPTION
While defining the model it was giving error while converting the lookback period value an integer into type shape. So I fixed that by changing  x = tf.keras.layers.Input(shape=len(backcast_time_idx)) into x = tf.keras.layers.Input(shape=(len(backcast_time_idx),)) so that it takes the lookback period as a tuple here.